### PR TITLE
Flattens result of a chromosome's recombination method

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ class StringPopulation < Array
     cross_point = (rand * c2.size).to_i
     c1_a, c1_b = self.separate(cross_point)
     c2_a, c2_b = c2.separate(cross_point)
-    [StringPopulation.new(c1_a + c2_b), StringPopulation.new(c2_a + c1_b)]
+    StringPopulation.new(c1_a + c2_b)
   end
 
   def mutate

--- a/lib/gga4r.rb
+++ b/lib/gga4r.rb
@@ -66,7 +66,7 @@ class GeneticAlgorithm
       @logger.debug "Recombining" if @logger
       new_children << chromosome1.recombine(chromosome2)
     end
-    new_generation + new_children
+    new_generation + new_children.flatten(1)
   end
 
   # Mutates population

--- a/lib/gga4r.rb
+++ b/lib/gga4r.rb
@@ -11,10 +11,13 @@ class GeneticAlgorithm
   #  Accepts the next properties:
   #   - max_population: maximum number of individuals that are allowed to form a generation.
   #   - logger: logger to write messages if given.
+  #   - multi_recombination: set to true if the result of a chromosome's #recombination method
+  #     returns an array. Default to false
   def initialize(in_pop, prop = {})
     @max_population =  prop[:max_population]
     @logger = prop[:logger] || Logger.new('/dev/null')
     @population = in_pop
+    @multi_recombination = prop[:multi_recombination] || false
     @generations = []
   end
 
@@ -66,7 +69,8 @@ class GeneticAlgorithm
       @logger.debug "Recombining" if @logger
       new_children << chromosome1.recombine(chromosome2)
     end
-    new_generation + new_children.flatten(1)
+    new_children.flatten!(1) if @multi_recombination
+    new_generation + new_children
   end
 
   # Mutates population

--- a/test/gga4r_test.rb
+++ b/test/gga4r_test.rb
@@ -9,7 +9,7 @@ class IndividualStub < Array
   end
 
   def recombine(a)
-    [self * 2, self * 2]
+    self * 2
   end
 
   def self.create_random_population(num_population = 30)
@@ -61,7 +61,9 @@ class Gga4rTest < Test::Unit::TestCase
   end
 
   def test_multiple_recombination
-    ga = GeneticAlgorithm.new(StringPopulation.create_population)
+    opts = {multi_recombination: true}
+    ga = GeneticAlgorithm.new(StringPopulation.create_population, opts)
+    assert ga.instance_variable_get(:@multi_recombination)
     4.times { |i| ga.evolve }
     p ga.best_fit[0]
   end

--- a/test/gga4r_test.rb
+++ b/test/gga4r_test.rb
@@ -21,13 +21,48 @@ class IndividualStub < Array
   end
 end
 
+class StringPopulation < Array
+  def fitness
+    fitness = self.select { |pos| pos == 1 }.size.to_f / self.size.to_f
+    fitness
+  end
+
+  def recombine(c2)
+    cross_point = rand([self.size, c2.size].min) + 1
+    c1_a, c1_b = self.slice(0,cross_point), self.slice(cross_point, 0)
+    c2_a, c2_b = c2.slice(0,cross_point), c2.slice(cross_point, 0)
+    [StringPopulation.new(c1_a + c2_b), StringPopulation.new(c2_a + c1_b)]
+  end
+
+  def mutate
+    mutate_point = (rand * self.size).to_i
+    self[mutate_point] = 1
+  end
+
+  def self.create_population(s_long = 10, num = 10)
+    population = []
+    num.times  do
+      chromosome = self.new(Array.new(s_long).collect { (rand > 0.2) ? 0:1 })
+      population << chromosome
+    end
+    population
+  end
+end
+
 class Gga4rTest < Test::Unit::TestCase
-  def test_evolve
+  def test_single_recombination_result
     first_pop_even = IndividualStub.create_random_population(30)
     ga = GeneticAlgorithm.new(first_pop_even)
-    ga.evolve()
-    new_pop = ga.instance_variable_get(:@population)
+    5.times do |i|
+      ga.evolve
+      new_pop = ga.instance_variable_get(:@population)
+      assert first_pop_even.size < new_pop.size
+    end
+  end
 
-    assert first_pop_even.size < new_pop.size
+  def test_multiple_recombination
+    ga = GeneticAlgorithm.new(StringPopulation.create_population)
+    4.times { |i| ga.evolve }
+    p ga.best_fit[0]
   end
 end

--- a/test/gga4r_test.rb
+++ b/test/gga4r_test.rb
@@ -64,7 +64,10 @@ class Gga4rTest < Test::Unit::TestCase
     opts = {multi_recombination: true}
     ga = GeneticAlgorithm.new(StringPopulation.create_population, opts)
     assert ga.instance_variable_get(:@multi_recombination)
-    4.times { |i| ga.evolve }
-    p ga.best_fit[0]
+    4.times do |i|
+      assert_nothing_raised do
+        ga.evolve
+      end
+    end
   end
 end

--- a/test/gga4r_test.rb
+++ b/test/gga4r_test.rb
@@ -9,13 +9,13 @@ class IndividualStub < Array
   end
 
   def recombine(a)
-    self * 2
+    [self * 2, self * 2]
   end
 
   def self.create_random_population(num_population = 30)
     population = []
     num_population.times do
-      population << IndividualStub.new
+      population << IndividualStub.new([1,2,3])
     end
     return population
   end


### PR DESCRIPTION
When using gga4r, I followed the example in the readme to return an array of a chromosome's `recombination` method. From the [README](https://github.com/spejman/gga4r#introduction):

``` ruby
def recombine(c2)
    # some code...
    [StringPopulation.new(c1_a + c2_b), StringPopulation.new(c2_a + c1_b)]
end
```

When running a genetic algorithm with this chromosome, on the second evolution, an error is thrown because the chromosome in the population is an `Array`, which can't respond to a `recombine` or `mutate` method. A workaround for this is to simply return a chromosome as the result of `recombine`, but I wanted to also allow for returning multiple chromosomes. My fix for this situation is to accept a `multi_recombination` option in `GeneticAlgorithm.new`. When this option is set to `true`, you can return an array of chromosomes in a `recombine` method, similar to the above provided example.

I've also added tests to demonstrate this error. To reproduce, follow these steps:

``` bash
git reset a095eee
cd test
ruby gga4r_test.rb
```
